### PR TITLE
Add warning about pins used for JTAG

### DIFF
--- a/photon-shields/programmer-shield/README.md
+++ b/photon-shields/programmer-shield/README.md
@@ -1,3 +1,9 @@
+# Hardware Compatibility
+
+The Programmer Shield is compatible with the Photon and the Electron.
+
+**Pins D3, D4, D5, D6 and D7 (blue LED) are used for the JTAG signals** so your application code must not use those pins while using the Programmer Shield with OpenOCD. An alternative debug mode called SWD that uses only D6 and D7 can be configured in OpenOCD.
+
 # Installing OpenOCD for Particle Programmer Shield:
 
 ### OSX:


### PR DESCRIPTION
I've been bitten several times not being able to connect the debugger because my user code uses D7 (the blue LED). Let's warn others.